### PR TITLE
Handle paginated response on the want-list fetch hooks

### DIFF
--- a/src/app/mathtrade/my-wants/useWants.js
+++ b/src/app/mathtrade/my-wants/useWants.js
@@ -41,18 +41,23 @@ const useWants = () => {
 
   /* GET MY WANTS *************************************************/
   const afterLoadMyWants = useCallback(
-    (wantList) => {
-      setMyWants(wantList);
+    ({ results }) => {
+      setMyWants(results);
       setIsLoadedWants(true);
       setChanges({});
       setDeletedWantgroupIds({});
     },
     [setIsLoadedWants, setMyWants, setChanges, setDeletedWantgroupIds]
   );
+  // My own want-list is inherently bounded to one user's own entries, unlike
+  // a browsable list of everyone's items - request the max page size so it
+  // isn't silently truncated at the default page size (50).
+  const myWantsParams = useMemo(() => ({ page_size: 200 }), []);
   const [, , loadingMyWants, errorMyWants] = useFetch({
     endpoint: "MYWANTS",
     autoLoad: true,
-    initialState: [],
+    initialState: { results: [] },
+    params: myWantsParams,
     afterLoad: afterLoadMyWants,
   });
 

--- a/src/app/mathtrade/offer/games/useGames.js
+++ b/src/app/mathtrade/offer/games/useGames.js
@@ -3,6 +3,11 @@ import { useCallback, useState, useContext, useEffect } from "react";
 import { useOptions } from "@/store";
 import { PageContext } from "@/context/page";
 
+// My own want-list is inherently bounded to one user's own entries, unlike
+// a browsable list of everyone's games - request the max page size so it
+// isn't silently truncated at the default page size (50).
+const MY_OWN_DATA_PARAMS = { page_size: 200 };
+
 const useItems = () => {
   /* PAGE CONTEXT **********************************************/
   const {
@@ -77,16 +82,17 @@ const useItems = () => {
     setLoadingMyWants(true);
   }, [setLoadingMyWants]);
   const afterLoadMyWants = useCallback(
-    (wantList) => {
+    ({ results }) => {
       setLoadingMyWants(false);
-      setMyWants(wantList);
+      setMyWants(results);
     },
     [setLoadingMyWants, setMyWants]
   );
   useFetch({
     endpoint: "MYWANTS",
     autoLoad: true,
-    initialState: [],
+    initialState: { results: [] },
+    params: MY_OWN_DATA_PARAMS,
     beforeLoad: beforeLoadMyWants,
     afterLoad: afterLoadMyWants,
   });

--- a/src/app/mathtrade/offer/items/useItems.js
+++ b/src/app/mathtrade/offer/items/useItems.js
@@ -3,6 +3,11 @@ import { useCallback, useState, useContext, useEffect } from "react";
 import { useOptions } from "@/store";
 import { PageContext } from "@/context/page";
 
+// My own want-list is inherently bounded to one user's own entries, unlike
+// a browsable list of everyone's items - request the max page size so it
+// isn't silently truncated at the default page size (50).
+const MY_OWN_DATA_PARAMS = { page_size: 200 };
+
 const useItems = () => {
   /* PAGE CONTEXT **********************************************/
   const {
@@ -107,16 +112,17 @@ const useItems = () => {
     setLoadingMyWants(true);
   }, [setLoadingMyWants]);
   const afterLoadMyWants = useCallback(
-    (wantList) => {
+    ({ results }) => {
       setLoadingMyWants(false);
-      setMyWants(wantList);
+      setMyWants(results);
     },
     [setLoadingMyWants, setMyWants]
   );
   useFetch({
     endpoint: "MYWANTS",
     autoLoad: true,
-    initialState: [],
+    initialState: { results: [] },
+    params: MY_OWN_DATA_PARAMS,
     beforeLoad: beforeLoadMyWants,
     afterLoad: afterLoadMyWants,
   });


### PR DESCRIPTION
## What

Companion to a backend change that adds pagination to `GET /api/mathtrades/{id}/user-want-groups/` (returns `{ results, count, next }` instead of a bare array) — needed to stop a large want-list from costing an unbounded response. Requires the backend PR (`optimize/05-wantgroup-pagination-backend`) to be deployed for these endpoints to behave as expected.

## Change

- `my-wants/useWants.js`, `offer/items/useItems.js`, `offer/games/useGames.js` (the three call sites reading `MYWANTS`): destructure `results` out of the response instead of treating the payload as the list itself.
- Request `page_size=200` (the backend's max) on these specific calls rather than teaching these screens to walk `next` — this is always the current user's own want-list, a bounded per-user dataset, not a browsable list of everyone's items.

## Why not the existing `format:` pattern

This codebase already has a pattern for already-paginated endpoints (`format: (data) => data.results` passed inline to `useFetch`, used for `GET_ITEMS_LIST`/`GET_GAMES_LIST`). Tried that first here, but it caused a request loop: a literal arrow function passed as `format` is a new reference on every render, which breaks `useFetch`'s effect dependency stability and re-triggers `autoLoad` continuously (900+ pending requests to the same endpoint when this was caught in manual testing). Destructuring `results` inside the existing `afterLoad` callback avoids introducing a new unstable prop.

## Verification

No automated test runner in this repo (per its own docs). Verified manually against a local backend + seeded event: requests stay stable (no growth), and a want-group beyond the 50th row is present after the fix (was silently missing before, since nothing previously handled pagination on these calls at all).