### PR TITLE
Handle paginated response on the tags and results fetch hooks

### DIFF
--- a/src/app/mathtrade/offer/items/useItems.js
+++ b/src/app/mathtrade/offer/items/useItems.js
@@ -3,9 +3,9 @@ import { useCallback, useState, useContext, useEffect } from "react";
 import { useOptions } from "@/store";
 import { PageContext } from "@/context/page";
 
-// My own want-list is inherently bounded to one user's own entries, unlike
-// a browsable list of everyone's items - request the max page size so it
-// isn't silently truncated at the default page size (50).
+// My own tags/want-list are inherently bounded to one user's own entries,
+// unlike a browsable list of everyone's items - request the max page size
+// so they aren't silently truncated at the default page size (50).
 const MY_OWN_DATA_PARAMS = { page_size: 200 };
 
 const useItems = () => {
@@ -85,8 +85,8 @@ const useItems = () => {
 
   /* ITEM TAGS *********************************************/
   const afterLoadItemTags = useCallback(
-    (list) => {
-      const tags = list.map((tag, i) => {
+    ({ results }) => {
+      const tags = results.map((tag, i) => {
         return {
           ...tag,
           id: `${tag?.id || i}`,
@@ -101,8 +101,9 @@ const useItems = () => {
 
   useFetch({
     endpoint: "MYTAGS",
-    initialState: [],
+    initialState: { results: [] },
     autoLoad: true,
+    params: MY_OWN_DATA_PARAMS,
     afterLoad: afterLoadItemTags,
   });
   /* end ITEM TAGS *********************************************/

--- a/src/app/mathtrade/results/useResults.js
+++ b/src/app/mathtrade/results/useResults.js
@@ -65,8 +65,8 @@ const useResults = () => {
 
   /* GET USERS *************************************************/
   const afterLoadMTresults = useCallback(
-    (newMTresults) => {
-      setMathTradeResults(newMTresults);
+    ({ results }) => {
+      setMathTradeResults(results);
     },
     [setMathTradeResults]
   );
@@ -78,7 +78,9 @@ const useResults = () => {
 
   useEffect(() => {
     if (currentUser && currentUser.trades && currentUser.commitment) {
-      getMathTradeResults({ params: { user: currentUserId } });
+      getMathTradeResults({
+        params: { user: currentUserId, page_size: 200 },
+      });
     } else {
       setMathTradeResults(null);
     }

--- a/src/components/item-tags/item-tag-editor/useTagEditor.js
+++ b/src/components/item-tags/item-tag-editor/useTagEditor.js
@@ -28,8 +28,8 @@ const useTagEditor = (tag, onClose) => {
 
   /* ITEM TAGS *********************************************/
   const afterLoadItemTags = useCallback(
-    (list) => {
-      const tags = list.map((tag, i) => {
+    ({ results }) => {
+      const tags = results.map((tag, i) => {
         return {
           ...tag,
           id: `${tag?.id || i}`,
@@ -45,14 +45,16 @@ const useTagEditor = (tag, onClose) => {
 
   const [loadMyTags, , loadingMyTags] = useFetch({
     endpoint: "MYTAGS",
-    initialState: [],
+    initialState: { results: [] },
     afterLoad: afterLoadItemTags,
   });
   /* end ITEM TAGS *********************************************/
 
   /* PUT TAG ************************************************/
   const afterLoadPutMyItemTag = useCallback(() => {
-    loadMyTags();
+    // My own tags are inherently bounded to one user's own entries - request
+    // the max page size so they aren't silently truncated at the default (50).
+    loadMyTags({ params: { page_size: 200 } });
   }, [loadMyTags]);
 
   const [putMyItemTag, , loadingPut, errorPut] = useFetch({
@@ -64,7 +66,7 @@ const useTagEditor = (tag, onClose) => {
 
   /* POST TAG ************************************************/
   const afterLoadPostMyItemTag = useCallback(() => {
-    loadMyTags();
+    loadMyTags({ params: { page_size: 200 } });
   }, [loadMyTags]);
 
   const [postMyItemTag, , loadingPost, errorPost] = useFetch({
@@ -77,7 +79,7 @@ const useTagEditor = (tag, onClose) => {
   /* DELETE TAG ************************************************/
   const afterDeletePostMyItemTag = useCallback(() => {
     updateFilters({ tag: undefined }, "item");
-    loadMyTags();
+    loadMyTags({ params: { page_size: 200 } });
   }, [loadMyTags, updateFilters]);
 
   const [deleteMyItemTag, , loadingDelete] = useFetch({

--- a/src/components/item-tags/item-taglist/useItemTagList.js
+++ b/src/components/item-tags/item-taglist/useItemTagList.js
@@ -15,8 +15,8 @@ const useItemTagList = () => {
   /* end ITEM CONTEXT */
 
   const afterLoadItemTags = useCallback(
-    (list) => {
-      const tags = list.map((tag, i) => {
+    ({ results }) => {
+      const tags = results.map((tag, i) => {
         return {
           ...tag,
           id: `${tag?.id || i}`,
@@ -31,12 +31,14 @@ const useItemTagList = () => {
 
   const [getTagList, , loadingTags] = useFetch({
     endpoint: "MYTAGS",
-    initialState: [],
+    initialState: { results: [] },
     afterLoad: afterLoadItemTags,
   });
 
   const afterLoad = useCallback(() => {
-    getTagList();
+    // My own tags are inherently bounded to one user's own entries - request
+    // the max page size so they aren't silently truncated at the default (50).
+    getTagList({ params: { page_size: 200 } });
   }, [getTagList]);
 
   const [putTag, , loadingUpdateTag] = useFetch({


### PR DESCRIPTION
## What

Companion to the backend PR that adds pagination to `user-tags` and `results`. Requires that backend PR merged/deployed to behave correctly.

## Change

- Item-tag hooks (`item-tag-editor`, `item-taglist`, and the tags block in `offer/items/useItems.js`) and `results/useResults.js`: destructure `results` from the response instead of treating the payload as the list itself.
- Request `page_size=200` on these calls, same reasoning as the earlier want-list PR — these are always the current user's own bounded data (their tags, their own trade results), not a browsable list of everyone's, so requesting the max page size is simpler than teaching these screens to walk `next`.

## Verification

No automated test runner in this repo. Verified manually against a local backend + seeded event (tag creation/browse flow and the results page with 50+ tags/trades) — same approach used for the earlier want-list PR.

Depends on #29 in this repo (the want-list pagination hooks, since `offer/items/useItems.js` is shared between both changes).